### PR TITLE
Fix device initialization

### DIFF
--- a/pyavrdebug/pyavrdebug_main.py
+++ b/pyavrdebug/pyavrdebug_main.py
@@ -338,12 +338,17 @@ def pyavrdebug(args):
     # Use pymcuprog backend for initial connection here
     backend = Backend()
     toolconnection = _setup_tool_connection(args)
-    backend.connect_to_tool(toolconnection)
+    device = None
 
-    # Read device name from kit, but allow override
-    device = backend.read_kit_device()
-    if args.device:
-        device = args.device
+    try:
+        backend.connect_to_tool(toolconnection)
+
+        # Read device name from kit, but allow override
+        device = backend.read_kit_device()
+        if args.device:
+            device = args.device
+    finally:
+        backend.disconnect_from_tool()
 
     transport = hid_transport()
     transport.connect(serial_number=toolconnection.serialnumber, product=toolconnection.tool_name)


### PR DESCRIPTION
Without the `disconnect_from_tool()` call, the subsequent `transport.connect` will immediately fail because the device is already open. This commit fixes that. Also, using a try/finally block should make it not forget to close the backend in case an exception occurs.

Traceback I'm getting if this patch is not applied:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "pyavrdebug/pyavrdebug/__main__.py", line 3, in <module>
    pyavrdebug.pyavrdebug.main()
  File "pyavrdebug/pyavrdebug/pyavrdebug.py", line 131, in main
    return pyavrdebug_main.pyavrdebug(arguments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pyavrdebug/pyavrdebug/pyavrdebug_main.py", line 349, in pyavrdebug
    transport.connect(serial_number=toolconnection.serialnumber, product=toolconnection.tool_name)
  File "lib/python3.11/site-packages/pyedbglib/hidtransport/hidtransportbase.py", line 149, in connect
    self.hid_connect(self.device)
  File "lib/python3.11/site-packages/pyedbglib/hidtransport/cyhidapi.py", line 99, in hid_connect
    hid_device.open(device.vendor_id, device.product_id, device.serial_number)
  File "hid.pyx", line 139, in hid.device.open
OSError: open failed
```